### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 Mallory provides a robust source of cyber and threat intelligence. Use this MCP Server to enable your agents with real-time cyber threat intelligence and detailed information about vulnerabilities, threat actors, malware, techniques and other cyber-relevant entities and content. 
 
+<a href="https://glama.ai/mcp/servers/@malloryai/mallory-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@malloryai/mallory-mcp-server/badge" alt="Mallory Server MCP server" />
+</a>
+
 ## 📋 Prerequisites
 
 - Python 3.13 or higher


### PR DESCRIPTION
This PR adds a badge for the [Mallory MCP Server](https://glama.ai/mcp/servers/@malloryai/mallory-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@malloryai/mallory-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@malloryai/mallory-mcp-server/badge" alt="Mallory Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.